### PR TITLE
fix: standardize capitalization and punctuation in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-# Salarios de Desarrolladores en Colombia
+# Salarios de desarrolladores en Colombia
 Este repositorio contiene los resultados de encuestas sobre salarios de desarrolladores de software en Colombia y el sitio web para visualizarlos.
 
-## Sitio Web
+## Sitio web
 
 **Clonar el repositorio:**
    ```bash
@@ -18,15 +18,15 @@ Este repositorio contiene los resultados de encuestas sobre salarios de desarrol
    ```bash
    npm run dev
    ```
-   El sitio estará disponible en `http://localhost:5173`
+   El sitio estará disponible en `http://localhost:5173`.
 
-### Construcción y Despliegue
+### Construcción y despliegue
 
 1. **Construir para producción:**
    ```bash
    npm run build
    ```
-   Los archivos optimizados se generarán en el directorio `dist/`
+   Los archivos optimizados se generarán en el directorio `dist/`.
 
 2. **Vista previa de la construcción:**
    ```bash
@@ -38,19 +38,19 @@ Este repositorio contiene los resultados de encuestas sobre salarios de desarrol
    npm run deploy
    ```
 
-### Scripts Disponibles
-- `npm run dev` - Inicia el servidor de desarrollo
-- `npm run build` - Construye la aplicación para producción
-- `npm run preview` - Vista previa de la construcción local
-- `npm run deploy` - Despliega el sitio en GitHub Pages
-- `npm run lint` - Ejecuta el linter para verificar el código
+### Scripts disponibles
+- `npm run dev` - Inicia el servidor de desarrollo.
+- `npm run build` - Construye la aplicación para producción.
+- `npm run preview` - Vista previa de la construcción local.
+- `npm run deploy` - Despliega el sitio en GitHub Pages.
+- `npm run lint` - Ejecuta el linter para verificar el código.
 
 ## Encuesta 2025
 Los resultados se encuentran en directorio `data` bajo el prefijo `2025*.csv`. Recopilan información anónima sobre experiencia, formación, ubicación, nivel de inglés, lenguajes de programación, modalidad de trabajo, tipo de empresa, tipo de contrato y remuneración, entre otros datos relevantes. La información no ha pasado por un proceso de preprocesamiento, por lo que puede contener errores o inconsistencias. Se recomienda revisar los datos antes de utilizarlos para análisis o visualizaciones.
 
-**Agradecimientos Recolección:** Alejandro Rios, Andres Santos, Andres Villegas, Brayan Hurtado, Daniel Granados, Daniel Mendoza, Daniel Sanchez, Danilo Plazas, Diego Avila, Guillermo Rodas, Isaias De La Hoz, Jahir Fiquitiva, Jorge Morales, Juan Romero, Julian David, Julian Francor, Laura Ramos, Mateo Olarte, Ricardo Trejos, Sara Palacio, Sebastian Guevara, Wilson Tovar, Yeiner Fernandez.
+**Agradecimientos recolección de datos:** Alejandro Rios, Andres Santos, Andres Villegas, Brayan Hurtado, Daniel Granados, Daniel Mendoza, Daniel Sanchez, Danilo Plazas, Diego Avila, Guillermo Rodas, Isaias De La Hoz, Jahir Fiquitiva, Jorge Morales, Juan Romero, Julian David, Julian Franco Rua, Laura Ramos, Mateo Olarte, Ricardo Trejos, Sara Palacio, Sebastian Guevara, Wilson Tovar, Yeiner Fernandez.
 
-**Agradecimientos Sitio:** [Audreylopez22](https://github.com/Audreylopez22).
+**Agradecimientos sitio web:** [Audreylopez22](https://github.com/Audreylopez22).
 
 ## Licencia
 


### PR DESCRIPTION
This PR improves the README by standardizing capitalization and adding consistent punctuation:

 - Capitalization fixes: Updated section headers from title case to sentence case ("Sitio Web" → "Sitio web", "Construcción y Despliegue" → "Construcción y despliegue", "Scripts Disponibles" → "Scripts disponibles").
 
- Punctuation consistency: Added periods to the end of sentences and bullet points for better formatting and readability.

- Acknowledgments clarity: Improved acknowledgment sections with clearer labels ("Agradecimientos recolección de datos" and "Agradecimientos sitio web").

- Minor corrections: Fixed contributor name from "Julian Francor" to "Julian Franco Rua".